### PR TITLE
Enabling support for MacOS laptop installation

### DIFF
--- a/setup/configure
+++ b/setup/configure
@@ -1,9 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import subprocess
-from tempfile import TemporaryDirectory as tmpdir
 import os
-from pathlib import Path
 from datetime import datetime
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -11,7 +9,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def get_current_time():
     now = datetime.now().strftime("%H:%M:%S")
-    return f"({now})"
+    return "({})".format(now)
 
 
 def detect_platform():
@@ -37,9 +35,9 @@ def run_script(script, my_env):
     )
 
     out, err = process_output.communicate()
-    out, err = out.strip().decode(), err.strip().decode()
+    #out, err = out.strip().decode(), err.strip().decode()
     if process_output.returncode != 0:
-        raise RuntimeError(f"{script} script failed: {process_output.returncode} {out} {err}")
+        raise RuntimeError("{} script failed: {} {} {}".format(script, process_output.returncode, out, err))
 
 
 def prepare_env():
@@ -61,53 +59,51 @@ def prepare_env():
 
     conda_path = detect_existing_executable("conda")
     if conda_path is not None:
-        print(f"****** Found an existing Conda installation in: {conda_path} ******")
-        print(f"****** Step 1/5: Skipping Conda installation {get_current_time()} ******")
+        print("****** Found an existing Conda installation in: {} ******".format(conda_path))
+        print("****** Step 1/5: Skipping Conda installation {} ******".format(get_current_time()))
 
     else:
-        print(f"****** Step 1/5: Installing Miniconda {get_current_time()} ******")
+        print("****** Step 1/5: Installing Miniconda {} ******".format(get_current_time()))
         plat = detect_platform()
         if plat["system"] in installers:
             my_env["INSTALLER"] = installers[plat["system"]]
             if plat["node"].startswith("casper") or plat["node"].startswith("cheyenne"):
-                install_dir = f'/glade/work/{my_env["USER"]}/miniconda3'
+                install_dir = '/glade/work/{}/miniconda3'.format(my_env["USER"])
             else:
-                install_dir = f'{my_env["HOME"]}/miniconda3'
+                install_dir = '{}/miniconda3'.format(my_env["HOME"])
 
             my_env["INSTALL_DIR"] = install_dir
 
-            with tmpdir():
-
-                install_script = os.path.join(here, "install_conda")
-                run_script(install_script, my_env)
+            install_script = os.path.join(here, "install_conda")
+            run_script(install_script, my_env)
 
         else:
             raise RuntimeError("Unsupported Platform...")
 
     if "INSTALL_DIR" not in my_env:
-        my_env["INSTALL_DIR"] = Path(conda_path).parent.parent.as_posix()
+        my_env["INSTALL_DIR"] = os.path.abspath(os.path.join(os.path.dirname(conda_path), '..'))
 
-    print(f"****** Step 2/5: Updating `base` environment {get_current_time()} ******")
+    print("****** Step 2/5: Updating `base` environment {} ******".format(get_current_time()))
     run_script(os.path.join(here, "update_base_env"), my_env)
     print(
-        "****** Step 3/5: Creating/Updating `analysis` environment",
-         f"(this can take several minutes) {get_current_time()} ******"
+        "****** Step 3/5: Creating/Updating `analysis` environment "
+        "(this can take several minutes) {} ******".format(get_current_time())
     )
     run_script(os.path.join(here, "update_analysis_env"), my_env)
 
     print(
-        "****** Step 4/5: Running post build script for `base` environment",
-         f"{get_current_time()} ******"
+        "****** Step 4/5: Running post build script for `base` environment "
+        "{} ******".format(get_current_time())
     )
     run_script(os.path.join(here, "post_build_base"), my_env)
     print(
-        "****** Step 5/5: Running post build script for `analysis` environment",
-        f"(this can take several minutes) {get_current_time()} ******"
+        "****** Step 5/5: Running post build script for `analysis` environment" 
+        "(this can take several minutes) {} ******".format(get_current_time())
     )
     my_env["CARTOPY_ASSET_SCRIPT"] = os.path.join(here, "download_cartopy_assets.py")
     run_script(os.path.join(here, "post_build_analysis"), my_env)
 
-    print(f"****** Setup completed successfully. {get_current_time()} ******")
+    print("****** Setup completed successfully. {} ******".format(get_current_time()))
     print("==> For changes to take effect, close and re-open your current shell. <==")
 
 

--- a/setup/configure
+++ b/setup/configure
@@ -59,11 +59,12 @@ def prepare_env():
 
     conda_path = detect_existing_executable("conda")
     if conda_path is not None:
-        print("****** Found an existing Conda installation in: {} ******".format(conda_path))
-        print("****** Step 1/5: Skipping Conda installation {} ******".format(get_current_time()))
+        print("*** Found an existing Conda installation in: {}".format(conda_path))
+        print("*** {} Step 1/5: Skipping Conda installation".format(get_current_time()))
+        my_env["INSTALL_DIR"] = os.path.abspath(os.path.join(os.path.dirname(conda_path), '..'))
 
     else:
-        print("****** Step 1/5: Installing Miniconda {} ******".format(get_current_time()))
+        print("*** {} Step 1/5: Installing Miniconda".format(get_current_time()))
         plat = detect_platform()
         if plat["system"] in installers:
             my_env["INSTALLER"] = installers[plat["system"]]
@@ -80,30 +81,26 @@ def prepare_env():
         else:
             raise RuntimeError("Unsupported Platform...")
 
-    if "INSTALL_DIR" not in my_env:
-        my_env["INSTALL_DIR"] = os.path.abspath(os.path.join(os.path.dirname(conda_path), '..'))
-
-    print("****** Step 2/5: Updating `base` environment {} ******".format(get_current_time()))
+    print("*** {} Step 2/5: Updating `base` environment".format(get_current_time()))
     run_script(os.path.join(here, "update_base_env"), my_env)
     print(
-        "****** Step 3/5: Creating/Updating `analysis` environment "
-        "(this can take several minutes) {} ******".format(get_current_time())
+        ("*** {} Step 3/5: Creating/Updating `analysis` environment "
+         "(this can take several minutes)").format(get_current_time())
     )
     run_script(os.path.join(here, "update_analysis_env"), my_env)
 
     print(
-        "****** Step 4/5: Running post build script for `base` environment "
-        "{} ******".format(get_current_time())
+        "*** {} Step 4/5: Running post build script for `base` environment".format(get_current_time())
     )
     run_script(os.path.join(here, "post_build_base"), my_env)
     print(
-        "****** Step 5/5: Running post build script for `analysis` environment" 
-        "(this can take several minutes) {} ******".format(get_current_time())
+        ("*** {} Step 5/5: Running post build script for `analysis` environment " 
+         "(this can take several minutes)").format(get_current_time())
     )
     my_env["CARTOPY_ASSET_SCRIPT"] = os.path.join(here, "download_cartopy_assets.py")
     run_script(os.path.join(here, "post_build_analysis"), my_env)
 
-    print("****** Setup completed successfully. {} ******".format(get_current_time()))
+    print("*** {} Setup completed successfully.".format(get_current_time()))
     print("==> For changes to take effect, close and re-open your current shell. <==")
 
 

--- a/setup/install_conda
+++ b/setup/install_conda
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 
+WGET=`which wget`
+CURL=`which curl`
+
 set -xeo pipefail
 
-wget $INSTALLER -O miniconda.sh -q
+if [ "$WGET" = "" ] && [ "$CURL" = "" ]; then
+  exit 255
+fi
+
+if [ "$WGET" = "" ]; then
+  curl -o miniconda.sh -s $INSTALLER
+else
+  wget $INSTALLER -O miniconda.sh -q
+fi
+
 chmod +x miniconda.sh
+mkdir -p ~/.conda
 ./miniconda.sh -b -p $INSTALL_DIR
+rm miniconda.sh

--- a/setup/update_base_env
+++ b/setup/update_base_env
@@ -10,13 +10,13 @@ conda config --set channel_priority strict
 conda config --set show_channel_urls True
 conda config --set pip_interop_enabled True
 
-conda update -q conda
+conda update -q -y conda
 conda env update -q -f $BASE_ENV_YML
 
 conda info -a
 
 if [ -z "$INIT_SHELL" ]; then
-   echo "INIT_SHELL is unset. Skipping conda init INIT_SHELL";
+  echo "INIT_SHELL is unset. Skipping conda init INIT_SHELL";
 else
   conda init $INIT_SHELL;
 fi


### PR DESCRIPTION
Fixes #41 

- Makes the `setup/configure` script work with Python 2 and Python 3
- Adds the ability to use `curl` or `wget` for downloading the Miniconda installer
- Modifies the formatting of the output

This has been tested on my personal (clean) Mac Book Pro, and I verified that the installation process works on Cheyenne, tool