### PR TITLE
Pin distributed version to fix dask-jobqueue issue

### DIFF
--- a/setup/environments/env-conda-base.yml
+++ b/setup/environments/env-conda-base.yml
@@ -2,7 +2,7 @@ name: base
 channels:
   - conda-forge
 dependencies:
-  - dask
+  - dask==2.3
   - dask-labextension
   - ipywidgets
   - jupyter_contrib_nbextensions

--- a/setup/environments/env-conda-base.yml
+++ b/setup/environments/env-conda-base.yml
@@ -2,7 +2,8 @@ name: base
 channels:
   - conda-forge
 dependencies:
-  - dask==2.3
+  - dask
+  - distributed==2.3
   - dask-labextension
   - ipywidgets
   - jupyter_contrib_nbextensions

--- a/setup/environments/env-tutorial.yml
+++ b/setup/environments/env-tutorial.yml
@@ -12,7 +12,8 @@ dependencies:
 - cftime
 - cmocean
 - cython
-- dask==2.3
+- dask
+- distributed==2.3
 - dask-jobqueue
 - dask-mpi
 - datashader

--- a/setup/environments/env-tutorial.yml
+++ b/setup/environments/env-tutorial.yml
@@ -12,7 +12,7 @@ dependencies:
 - cftime
 - cmocean
 - cython
-- dask
+- dask==2.3
 - dask-jobqueue
 - dask-mpi
 - datashader


### PR DESCRIPTION
@kmpaul, 

we may need to send an update asking folks who recently created the new environments to make sure that they are not running the latest version of `distributed` (version 2.4) which seem to be incompatible with the current version of `dask-jobqueue`....

See https://github.com/dask/dask-jobqueue/issues/339