### PR TITLE
jlab-hobart now submits walltime with request

### DIFF
--- a/setup/jlab/jlab-hobart
+++ b/setup/jlab/jlab-hobart
@@ -89,6 +89,7 @@ s=$(qsub << EOF
 #PBS -r n
 #PBS -q ${queue}
 #PBS -l nodes=${NODES}:ppn=${PPN}
+#PBS -l walltime=${walltime}
 #PBS -o ${WORKDIR}/
 #PBS -e ${WORKDIR}/
 #PBS -j oe


### PR DESCRIPTION
With this change PBS log shows

```
10/08/2019 12:57:26  A    user=dcherian group=cgdoce jobname=jlab-hobart queue=medium ctime=1570561026 qtime=1570561026 etime=1570561026 start=1570561046 owner=dcherian@hobart.cgd.ucar.edu
                          exec_host=h023.cgd.ucar.edu/0-47 Resource_List.cput=48:00:00 Resource_List.neednodes=1:ppn=48 Resource_List.nodect=1 Resource_List.nodes=1:ppn=48
                          Resource_List.walltime=08:00:00 
```

Previously (note no walltime in this one)
```
10/08/2019 12:55:22  A    user=dcherian group=cgdoce jobname=jlab-hobart queue=medium ctime=1570560892 qtime=1570560892 etime=1570560892 start=1570560922 owner=dcherian@hobart.cgd.ucar.edu
                          exec_host=h023.cgd.ucar.edu/0-47 Resource_List.cput=48:00:00 Resource_List.neednodes=1:ppn=48 Resource_List.nodect=1 Resource_List.nodes=1:ppn=48 
```